### PR TITLE
use msvc version mapping not based on python version

### DIFF
--- a/recipes/boost/bld.bat
+++ b/recipes/boost/bld.bat
@@ -1,14 +1,18 @@
 :: Set the right msvc version according to Python version
-if "%PY_VER%"=="2.7" (
-    set MSVC_VER=9.0
-    set LIB_VER=90
-) else if "%PY_VER%"=="3.4" (
-    set MSVC_VER=10.0
-    set LIB_VER=100
-) else (
-    set MSVC_VER=14.0
-    set LIB_VER=140
-)
+REM write a temporary batch file to map cl.exe version to visual studio version
+echo @echo 15=9 > msvc_versions.bat
+echo @echo 16=10 >> msvc_versions.bat
+echo @echo 17=11 >> msvc_versions.bat
+echo @echo 18=12 >> msvc_versions.bat
+echo @echo 19=14 >> msvc_versions.bat
+
+REM Run cl.exe to find which version our compiler is
+for /f "delims=" %%A in ('cl /? 2^>^&1 ^| findstr /C:"Version"') do set "CL_TEXT=%%A"
+FOR /F "tokens=1,2 delims==" %%i IN ('msvc_versions.bat') DO echo %CL_TEXT% | findstr /C:"Version %%i" > nul && set VSTRING=%%j && goto FOUND
+EXIT 1
+:FOUND
+
+call :TRIM VSTRING %VSTRING%
 
 :: Start with bootstrap
 call bootstrap.bat
@@ -18,7 +22,7 @@ if errorlevel 1 exit 1
 .\b2 install ^
     --build-dir=buildboost ^
     --prefix=%LIBRARY_PREFIX% ^
-    toolset=msvc-%MSVC_VER% ^
+    toolset=msvc-%VSTRING%.0 ^
     address-model=%ARCH% ^
     variant=release ^
     threading=multi ^
@@ -33,5 +37,12 @@ move %LIBRARY_INC%\boost-1_60\boost %LIBRARY_INC%
 if errorlevel 1 exit 1
 
 :: Move dll's to LIBRARY_BIN
-move %LIBRARY_LIB%\*vc%LIB_VER%-mt-1_60.dll "%LIBRARY_BIN%"
+move %LIBRARY_LIB%\*vc%VSTRING%0-mt-1_60.dll "%LIBRARY_BIN%"
 if errorlevel 1 exit 1
+
+
+:TRIM
+  SetLocal EnableDelayedExpansion
+  set Params=%*
+  for /f "tokens=1*" %%a in ("!Params!") do EndLocal & set %1=%%b
+  exit /B


### PR DESCRIPTION
Tying compiler version to python version is not good - people who build their own Python ecosystems, like @ukoethe, can't work with that method.

This is a better approach, and is the content of the Anaconda recipe.
