### PR TITLE
Fix OS X issue and build gmpxx on Linux

### DIFF
--- a/recipes/gmp/build.sh
+++ b/recipes/gmp/build.sh
@@ -2,11 +2,7 @@
 
 chmod +x configure
 
-if [ `uname` == Darwin ]; then
-    ./configure --prefix=$PREFIX --enable-cxx
-else
-    ./configure --prefix=$PREFIX
-fi
+./configure --prefix=$PREFIX --enable-cxx
 
 make
 make check

--- a/recipes/gmp/run_test.sh
+++ b/recipes/gmp/run_test.sh
@@ -1,2 +1,2 @@
-cc -I $PREFIX/include -L $PREFIX/lib test.c -lgmp -o test.out
+cc -I $PREFIX/include -L $PREFIX/lib test.c -lgmp -Wl,-rpath,$PREFIX/lib -o test.out
 ./test.out


### PR DESCRIPTION
Issue with OS X was that `./test.out` was picking an old gmp library (probably from Homebrew).
