### PR TITLE
Add setuptools as a runtime requirement

### DIFF
--- a/recipes/astroid/meta.yaml
+++ b/recipes/astroid/meta.yaml
@@ -26,6 +26,7 @@ requirements:
 
   run:
     - python
+    - setuptools
     - six
     - lazy_object_proxy
     - wrapt
@@ -34,6 +35,8 @@ test:
   imports:
     - astroid
     - astroid.tests
+    # import modutils to expose the setuptools runtime requirement
+    - astroid.modutils
 
 about:
   home: https://github.com/PyCQA/astroid


### PR DESCRIPTION
conda-forge is not packaging setuptools as part of python 3.5.  As such,
any packages that previously expected things like `pkg_resources` to come
with python3.5 now need explicit runtime dependencies on setuptools to
be listed.
